### PR TITLE
Change StreamHandler to use sys.stderr

### DIFF
--- a/nina_advanced_mcp.py
+++ b/nina_advanced_mcp.py
@@ -57,7 +57,7 @@ logging.basicConfig(
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
     handlers=[
         logging.FileHandler(log_file),
-        logging.StreamHandler()
+        logging.StreamHandler(sys.stderr)
     ]
 )
 logger = logging.getLogger('NinaAdvancedAPI')


### PR DESCRIPTION
fix: redirect StreamHandler to stderr to prevent stdio transport corruption 

StreamHandler() defaults to stdout, which conflicts with the MCP stdio transport. Log output gets parsed as JSON-RPC messages, causing JSONRPCMessage validation errors on startup.